### PR TITLE
Prepend space

### DIFF
--- a/testhook/templatetags/testhook.py
+++ b/testhook/templatetags/testhook.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.utils.safestring import mark_safe
 from django.utils.text import slugify
 
-if sys.version_info[0] == 3:
+if sys.version_info[0] > 2:
     basestring = str
 
 register = Library()

--- a/testhook/templatetags/testhook.py
+++ b/testhook/templatetags/testhook.py
@@ -26,7 +26,7 @@ def testhook(name, *args):
         name = '{}-{}'.format(name, concatted)
 
     return mark_safe(
-        u'data-testhook-id="{0}"'.format(
+        u' data-testhook-id="{0}"'.format(
             slugify(name)
         )
     )

--- a/testhook/tests.py
+++ b/testhook/tests.py
@@ -17,20 +17,20 @@ class TesthookTagTests(SimpleTestCase):
 
     def test_testhook_name_only(self):
         self.assertEqual(
-            _render('{% testhook "example" %}'), 'data-testhook-id="example"'
+            _render('{% testhook "example" %}'), ' data-testhook-id="example"'
         )
         self.assertEqual(
             _render('{% testhook "example-with-dash" %}'),
-            'data-testhook-id="example-with-dash"'
+            ' data-testhook-id="example-with-dash"'
         )
 
         self.assertEqual(
             _render('{% testhook "Just Do It" %}'),
-            'data-testhook-id="just-do-it"'
+            ' data-testhook-id="just-do-it"'
         )
         self.assertEqual(
             _render('{% testhook "Just_Do_It" %}'),
-            'data-testhook-id="just_do_it"'
+            ' data-testhook-id="just_do_it"'
         )
 
     def test_testhook_no_name(self):
@@ -45,12 +45,12 @@ class TesthookTagTests(SimpleTestCase):
     def test_testhook_additional_arguments(self):
         self.assertEqual(
             _render('{% testhook "prepend" "addon" %}'),
-            'data-testhook-id="prepend-addon"'
+            ' data-testhook-id="prepend-addon"'
         )
 
         self.assertEqual(
             _render('{% testhook "prepend" "Add On" %}'),
-            'data-testhook-id="prepend-add-on"'
+            ' data-testhook-id="prepend-add-on"'
         )
 
         context = {"product": {"id": 1, "slug": "unique-slug"}}
@@ -59,5 +59,5 @@ class TesthookTagTests(SimpleTestCase):
                 '{% testhook "prepend" product.id product.slug %}',
                 context
             ),
-            'data-testhook-id="prepend-1-unique-slug"'
+            ' data-testhook-id="prepend-1-unique-slug"'
         )


### PR DESCRIPTION
This PR will prepend a space in the ``templatetag`` output so there won't be any extra spaces when the ``testhooks`` are disabled.. saves 1 byte per testhook 🤘